### PR TITLE
drop index

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-linked-list"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "An actually useful linked list :) documentation will follow."
@@ -10,4 +10,4 @@ keywords = ["linked", "list", "vec", "array", "pinned"]
 categories = ["data-structures"]
 
 [dependencies]
-orx-imp-vec = "0.9.0"
+orx-imp-vec = "0.9.1"

--- a/src/node.rs
+++ b/src/node.rs
@@ -4,18 +4,16 @@ pub struct LinkedListNode<'a, T> {
     pub(crate) data: Option<T>,
     pub(crate) prev: Option<&'a LinkedListNode<'a, T>>,
     pub(crate) next: Option<&'a LinkedListNode<'a, T>>,
-    pub(crate) ind: usize,
 }
 impl<'a, T> LinkedListNode<'a, T> {
     pub(crate) fn back_front_node() -> Self {
-        Self::closed_node(0)
+        Self::closed_node()
     }
-    pub(crate) fn closed_node(ind: usize) -> Self {
+    pub(crate) fn closed_node() -> Self {
         Self {
             data: None,
             prev: None,
             next: None,
-            ind,
         }
     }
 }

--- a/src/utilization.rs
+++ b/src/utilization.rs
@@ -247,7 +247,7 @@ where
                     last_occupied_idx = occupied_idx;
 
                     // update occupied's prev & next
-                    let prev_idx = self.imp[occupied_idx].prev.map(|node| node.ind);
+                    let prev_idx = self.node_ind(self.imp[occupied_idx].prev);
                     if let Some(prev_idx) = prev_idx {
                         self.imp.set_next(prev_idx, Some(vacant_idx));
                     } else {
@@ -255,7 +255,7 @@ where
                         self.set_front(Some(vacant_idx));
                     }
 
-                    let next_idx = self.imp[occupied_idx].next.map(|node| node.ind);
+                    let next_idx = self.node_ind(self.imp[occupied_idx].next);
                     if let Some(next_idx) = next_idx {
                         self.imp.set_prev(next_idx, Some(vacant_idx));
                     } else {
@@ -265,7 +265,6 @@ where
 
                     // write to vacant from occupied
                     unsafe { self.imp.unsafe_swap(vacant_idx, occupied_idx) };
-                    self.imp[vacant_idx].ind = vacant_idx;
                 } else {
                     break;
                 }


### PR DESCRIPTION
`LinkedListNode `  no longer requires to keep `ind: usize`.

This has been possible due to the updates in the `PinnedVec`, and therefore, in the `ImpVec` crates, making referential `index_of` method available which computes faster than linear time.

This has the following impact on the code:

* linked list node is composed of 3 pointers rather than 4 pointers -> memory requirement is reduced by a quarter,
* linked list does not rely on raw numbers as reference addresses; instead, it relies on thin references which are kept valid due to the underlying `PinnedVec`.