### PR TITLE
structural immutability is allowed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-linked-list"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "An efficient doubly linked list using thin references with a focus on better cache locality avoiding heap allocations by smart pointers."
@@ -10,4 +10,4 @@ keywords = ["linked", "list", "vec", "array", "pinned"]
 categories = ["data-structures"]
 
 [dependencies]
-orx-imp-vec = "0.9.5"
+orx-imp-vec = "0.9.6"

--- a/src/collect.rs
+++ b/src/collect.rs
@@ -1,7 +1,20 @@
-use crate::{node::LinkedListNode, LinkedList};
+use crate::{node::LinkedListNode, LinkedList, LinkedListX};
 use orx_imp_vec::prelude::PinnedVec;
 
 impl<'a, T, P> LinkedList<'a, T, P>
+where
+    T: Clone,
+    P: PinnedVec<LinkedListNode<'a, T>> + 'a,
+{
+    /// Clones and collects values in the linked list into a standard vector.
+    ///
+    /// `self.collect_vec()` is simply a shorthand for `self.iter().cloned().collect()`.
+    pub fn collect_vec(&self) -> Vec<T> {
+        self.iter().cloned().collect()
+    }
+}
+
+impl<'a, T, P> LinkedListX<'a, T, P>
 where
     T: Clone,
     P: PinnedVec<LinkedListNode<'a, T>> + 'a,

--- a/src/fixed_vec.rs
+++ b/src/fixed_vec.rs
@@ -33,7 +33,7 @@ impl<'a, T> LinkedList<'a, T, FixedVec<LinkedListNode<'a, T>>> {
     /// Note that since `FixedVec` has a strict capacity; pushing to the list
     /// while there is no room leads to a panic.
     pub fn room(&self) -> usize {
-        self.imp.room()
+        self.vec.room()
     }
 }
 

--- a/src/iterator/iter.rs
+++ b/src/iterator/iter.rs
@@ -1,4 +1,4 @@
-use crate::{node::LinkedListNode, prelude::LinkedList};
+use crate::{linked_list::IS_SOME, node::LinkedListNode, prelude::LinkedList, LinkedListX};
 use orx_imp_vec::prelude::PinnedVec;
 use std::iter::FusedIterator;
 
@@ -34,7 +34,7 @@ where
         'a: 'b,
     {
         IterFromFront {
-            curr: self.imp[0].prev,
+            curr: self.vec[0].prev,
             len: self.len,
         }
     }
@@ -65,7 +65,77 @@ where
         'a: 'b,
     {
         IterFromBack {
-            curr: self.imp[0].next,
+            curr: self.vec[0].next,
+            len: self.len,
+        }
+    }
+}
+impl<'a, T, P> LinkedListX<'a, T, P>
+where
+    P: PinnedVec<LinkedListNode<'a, T>> + 'a,
+    T: 'a,
+{
+    /// Provides a forward iterator;
+    /// which starts from the front-most element to the back.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use orx_linked_list::prelude::*;
+    ///
+    /// let mut list = LinkedList::with_linear_growth(4);
+    ///
+    /// list.push_back(1);
+    /// list.push_back(2);
+    /// list.push_front(0);
+    /// list.push_back(3);
+    ///
+    /// let list = list.built();
+    /// let mut iter = list.iter();
+    /// assert_eq!(iter.next(), Some(&0));
+    /// assert_eq!(iter.next(), Some(&1));
+    /// assert_eq!(iter.next(), Some(&2));
+    /// assert_eq!(iter.next(), Some(&3));
+    /// assert_eq!(iter.next(), None);
+    /// ```
+    pub fn iter<'b>(&self) -> IterFromFront<'b, T>
+    where
+        'a: 'b,
+    {
+        IterFromFront {
+            curr: self.vec.get(0).expect(IS_SOME).prev,
+            len: self.len,
+        }
+    }
+    /// Provides a backward iterator;
+    /// which starts from the back-most element to the front.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use orx_linked_list::prelude::*;
+    ///
+    /// let mut list = LinkedList::with_linear_growth(4);
+    ///
+    /// list.push_back(1);
+    /// list.push_back(2);
+    /// list.push_front(0);
+    /// list.push_back(3);
+    ///
+    /// let list = list.built();
+    /// let mut iter = list.iter_from_back();
+    /// assert_eq!(iter.next(), Some(&3));
+    /// assert_eq!(iter.next(), Some(&2));
+    /// assert_eq!(iter.next(), Some(&1));
+    /// assert_eq!(iter.next(), Some(&0));
+    /// assert_eq!(iter.next(), None);
+    /// ```
+    pub fn iter_from_back<'b>(&self) -> IterFromBack<'b, T>
+    where
+        'a: 'b,
+    {
+        IterFromBack {
+            curr: self.vec.get(0).expect(IS_SOME).next,
             len: self.len,
         }
     }
@@ -130,77 +200,98 @@ impl<T> ExactSizeIterator for IterFromBack<'_, T> {
 mod tests {
     use super::*;
 
+    enum TestWithType {
+        WithLinkedList,
+        WithLinkedListX,
+    }
+
     #[test]
     fn next() {
-        let mut list = LinkedList::with_linear_growth(64);
+        fn test(test_with_type: TestWithType) {
+            let mut list = LinkedList::with_linear_growth(64);
 
-        list.push_back(2);
-        list.push_back(3);
-        list.push_front(1);
-        list.push_front(0);
-        list.push_back(4);
+            list.push_back(2);
+            list.push_back(3);
+            list.push_front(1);
+            list.push_front(0);
+            list.push_back(4);
 
-        assert_eq!(vec![0, 1, 2, 3, 4], list.collect_vec());
+            assert_eq!(vec![0, 1, 2, 3, 4], list.collect_vec());
 
-        let mut iter = list.iter();
-        assert_eq!(5, iter.len());
+            let mut iter = match test_with_type {
+                TestWithType::WithLinkedList => list.iter(),
+                TestWithType::WithLinkedListX => list.built().iter(),
+            };
 
-        assert_eq!(Some(&0), iter.next());
-        assert_eq!(4, iter.len());
+            assert_eq!(5, iter.len());
 
-        assert_eq!(Some(&1), iter.next());
-        assert_eq!(3, iter.len());
+            assert_eq!(Some(&0), iter.next());
+            assert_eq!(4, iter.len());
 
-        assert_eq!(Some(&2), iter.next());
-        assert_eq!(2, iter.len());
+            assert_eq!(Some(&1), iter.next());
+            assert_eq!(3, iter.len());
 
-        assert_eq!(Some(&3), iter.next());
-        assert_eq!(1, iter.len());
+            assert_eq!(Some(&2), iter.next());
+            assert_eq!(2, iter.len());
 
-        assert_eq!(Some(&4), iter.next());
-        assert_eq!(0, iter.len());
+            assert_eq!(Some(&3), iter.next());
+            assert_eq!(1, iter.len());
 
-        assert_eq!(None, iter.next());
-        assert_eq!(0, iter.len());
+            assert_eq!(Some(&4), iter.next());
+            assert_eq!(0, iter.len());
 
-        assert_eq!(None, iter.next());
-        assert_eq!(0, iter.len());
+            assert_eq!(None, iter.next());
+            assert_eq!(0, iter.len());
+
+            assert_eq!(None, iter.next());
+            assert_eq!(0, iter.len());
+        }
+        test(TestWithType::WithLinkedList);
+        test(TestWithType::WithLinkedListX);
     }
 
     #[test]
     fn next_rev() {
-        let mut list = LinkedList::with_linear_growth(64);
+        fn test(test_with_type: TestWithType) {
+            let mut list = LinkedList::with_linear_growth(64);
 
-        list.push_back(2);
-        list.push_back(3);
-        list.push_front(1);
-        list.push_front(0);
-        list.push_back(4);
+            list.push_back(2);
+            list.push_back(3);
+            list.push_front(1);
+            list.push_front(0);
+            list.push_back(4);
 
-        assert_eq!(vec![0, 1, 2, 3, 4], list.collect_vec());
+            assert_eq!(vec![0, 1, 2, 3, 4], list.collect_vec());
 
-        let mut iter = list.iter_from_back();
-        assert_eq!(5, iter.len());
+            let mut iter = match test_with_type {
+                TestWithType::WithLinkedList => list.iter_from_back(),
+                TestWithType::WithLinkedListX => list.built().iter_from_back(),
+            };
 
-        assert_eq!(Some(&4), iter.next());
-        assert_eq!(4, iter.len());
+            assert_eq!(5, iter.len());
 
-        assert_eq!(Some(&3), iter.next());
-        assert_eq!(3, iter.len());
+            assert_eq!(Some(&4), iter.next());
+            assert_eq!(4, iter.len());
 
-        assert_eq!(Some(&2), iter.next());
-        assert_eq!(2, iter.len());
+            assert_eq!(Some(&3), iter.next());
+            assert_eq!(3, iter.len());
 
-        assert_eq!(Some(&1), iter.next());
-        assert_eq!(1, iter.len());
+            assert_eq!(Some(&2), iter.next());
+            assert_eq!(2, iter.len());
 
-        assert_eq!(Some(&0), iter.next());
-        assert_eq!(0, iter.len());
+            assert_eq!(Some(&1), iter.next());
+            assert_eq!(1, iter.len());
 
-        assert_eq!(None, iter.next());
-        assert_eq!(0, iter.len());
+            assert_eq!(Some(&0), iter.next());
+            assert_eq!(0, iter.len());
 
-        assert_eq!(None, iter.next());
-        assert_eq!(0, iter.len());
+            assert_eq!(None, iter.next());
+            assert_eq!(0, iter.len());
+
+            assert_eq!(None, iter.next());
+            assert_eq!(0, iter.len());
+        }
+        test(TestWithType::WithLinkedList);
+        test(TestWithType::WithLinkedListX);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,6 +166,7 @@ mod fixed_vec;
 mod impl_bounded;
 mod iterator;
 mod linked_list;
+mod linked_list_x;
 mod mem;
 mod new;
 mod node;
@@ -174,6 +175,7 @@ pub mod prelude;
 mod variants;
 
 pub use crate::linked_list::LinkedList;
+pub use crate::linked_list_x::LinkedListX;
 pub use crate::mem::{MemoryStatus, MemoryUtilization};
 pub use crate::variants::{
     LinkedListDoubling, LinkedListExponential, LinkedListFixed, LinkedListLinear,

--- a/src/linked_list_x.rs
+++ b/src/linked_list_x.rs
@@ -1,0 +1,630 @@
+use crate::{linked_list::IS_SOME, node::LinkedListNode, LinkedList};
+use orx_imp_vec::prelude::{PinnedVec, SplitVec};
+use std::marker::PhantomData;
+
+/// `LinkedListX` is a **structurally immutable** `LinkedList`.
+/// In other words, it is a linked list which is done building:
+///
+/// * no insertions or removals are allowed from the list,
+/// * the list cannot be cleared.
+///
+/// On the other hand, having a mut reference, the data of the elements
+/// can still be mutated.
+///
+/// Note that it is possible to convert a `LinkedList` to a `LinkedListX`
+/// using `built(self)` and vice versa by `continue_building(self)` methods.
+/// Note that both methods are consuming; however, the conversion is cheap.
+///
+/// # Examples
+///
+/// Example below demonstrates how to switch between `LinkedList` and `LinkedListX`
+/// to designate whether structural mutations are allowed or not.
+///
+/// ```rust
+/// use orx_linked_list::prelude::*;
+///
+/// #[derive(Debug, PartialEq)]
+/// struct Wizard {
+///     name: String,
+///     level: u32,
+/// }
+/// impl Wizard {
+///     fn new<S: Into<String>>(name: S, level: u32) -> Self {
+///         Self {
+///             name: name.into(),
+///             level,
+///         }
+///     }
+///     fn cast_spell(&self) {}
+/// }
+///
+/// // build the structure: both mutable elements and structure
+/// let mut list: LinkedList<'_, Wizard> = LinkedList::new();
+/// list.push_back(Wizard::new("Gandalf", 99));
+/// list.push_front(Wizard::new("Sauron", 72));
+/// list.push_back(Wizard::new("Palpatine", 71));
+/// list.push_front(Wizard::new("Dumbledore", 86));
+/// assert_eq!(
+///     vec!["Dumbledore", "Sauron", "Gandalf", "Palpatine"],
+///     list.iter().map(|w| &w.name).collect::<Vec<_>>()
+/// );
+///
+/// // absolute immutable
+/// let list: LinkedListX<'_, Wizard> = list.built();
+/// for w in list.iter() {
+///     w.cast_spell();
+/// }
+///
+/// // back to structural mutations
+/// let mut list: LinkedList<'_, Wizard> = list.continue_building();
+/// let dumbledore = list.pop_front();
+/// assert_eq!(dumbledore, Some(Wizard::new("Dumbledore", 86)));
+/// list.push_back(Wizard::new("Merlin", 94));
+/// assert_eq!(
+///     vec!["Sauron", "Gandalf", "Palpatine", "Merlin"],
+///     list.iter().map(|w| &w.name).collect::<Vec<_>>()
+/// );
+///
+/// // stop structural mutations; however keep elements mutable
+/// let mut list: LinkedListX<'_, Wizard> = list.built();
+/// list.get_mut_at(1).unwrap().level += 1;
+/// assert_eq!(list.get_at(1), Some(&Wizard::new("Gandalf", 100)));
+///
+/// // back to structural mutations
+/// let mut list = list.continue_building();
+/// let gandalf = list.remove_at(1);
+/// assert_eq!(gandalf, Wizard::new("Gandalf", 100));
+///
+/// // freeze again
+/// let list = list.built();
+/// ```
+///
+/// # On structural immutablility
+///
+/// Together with standard rust `mut` choice, `LinkedList` and LinkedListX` together
+/// address the fact that im|mutability of collections is more than a boolean choice.
+///
+/// See the complete possibilities here:
+///
+/// | type              | element mutability | structural mutability | useful when/as |
+/// | :---              |        :----:      |         :----:        | :---   |
+/// |     `LinkedList`  | -                  | -                     | not really, see *Immutable `LinkedList` vs Immutable `LinkedListX`* |
+/// | `mut LinkedList`  | +                  | +                     | while building the linked list |
+/// |     `LinkedListX` | -                  | -                     | as an absolute immutable built linked list |
+/// | `mut LinkedListX` | -                  | +                     | as a structurally immutable built linked list; while values of nodes can be mutated but relations cannot be |
+///
+///
+/// ## Immutable `LinkedList` vs Immutable `LinkedListX`
+/// As you may see an immutable `LinkedList` is not very useful.
+///
+/// ```rust
+/// use orx_linked_list::prelude::*;
+///
+/// let list = LinkedList::<'_, char>::new();
+/// ```
+/// There is nothing to do with this `list`, it is and will be an empty list.
+///
+/// The situation is common. For instance, when we cannot convenitently `collect`,
+/// we create a `mut std::vec::Vec` build it up and move it
+/// to an immutable variable to make sure that the built vector will not be mutated.
+///
+/// Linked list is a self referencing data structure which is much harder to `collect`.
+/// In other words, building will probably require a `mut` reference.
+/// Therefore, this approach seems to fit and can be used in the same manner as in the
+/// example below.
+///
+/// ```rust
+/// use orx_linked_list::prelude::*;
+///
+/// let mut list = LinkedList::new();
+/// list.push_back('a');
+/// let list = list; // building is complete, no undesired mutation is allowed
+/// ```
+///
+/// However, to be able to build the inter-element relations via thin references,
+/// `LinkedList` makes use of `ImpVec`. `ImpVec` wraps a `PinnedVec` giving it the
+/// ability to define such relations with cheap thin references. It achieves this
+/// with one additional level of indirection which wraps the `PinnedVec`.
+///
+/// But if the structural mutation is complete, we do not need and will not use
+/// the ability to build inter-element references. Therefore, we can get rid of the
+/// additional indirection to reach the access performance of `PinnedVec`, rather than
+/// that of the `ImpVec`.
+///
+/// The transformation is convenient and cheap, and bidirectional.
+///
+/// Therefore, the usage below would be preferable to the example above:
+///
+/// ```rust
+/// use orx_linked_list::prelude::*;
+///
+/// let mut list = LinkedList::new();
+/// list.push_back('a');
+/// let list = list.built(); // building is complete, no undesired mutation is allowed
+/// ```
+///
+/// ## Recommended Usage
+///
+/// Therefore, the recommended usage of the linked list is as below:
+///
+/// * create and empty `mut LinkedList`,
+///     * `let mut list = LinkedList::new();`
+/// * keep it as `mut LinkedList` as long as structural mutations are ongoing:
+///     * cheap insertions and removals are the main features of a linked list;
+///     * therefore, in many cases, we might stay here until we drop the linked list.
+/// * if structural mutations are completed at some point, while we still need the data and built relations:
+///     * in addition to reference, if data of the elements are also immutable, convert it to `LinkedListX`:
+///         * `let list = list.built()`;
+///         * this allows faster access to elements than `LinkedList` while completely blocking all mutations.
+///     * otherwise if we still want to mutate the underlying values of the elements:
+///         * `let mut list = list.built()`;
+///         * this again allows faster access to elements than `LinkedList`,
+///         * no structural mutations are allowed, so references (node relations) will still stay intact,
+///         * however, underlying data of elements can be mutated.
+#[derive(Default)]
+pub struct LinkedListX<'a, T, P = SplitVec<LinkedListNode<'a, T>>>
+where
+    T: 'a,
+    P: PinnedVec<LinkedListNode<'a, T>> + 'a,
+{
+    pub(crate) vec: P,
+    pub(crate) len: usize,
+    pub(crate) marker: PhantomData<&'a T>,
+}
+
+impl<'a, T, P> LinkedListX<'a, T, P>
+where
+    T: 'a,
+    P: PinnedVec<LinkedListNode<'a, T>> + 'a,
+{
+    /// Converts the `LinkedListX` back to a `LinkedList` allowing for **structural mutability**.
+    ///
+    /// See the documentation of [`LinkedListX`] for details.
+    ///
+    /// The `LinkedList` is created with `MemoryUtilization::default()`, which can be updated
+    /// with `with_memory_utilization` method if needed.
+    pub fn continue_building(self) -> LinkedList<'a, T, P> {
+        LinkedList {
+            vec: self.vec.into(),
+            len: self.len,
+            memory_utilization: Default::default(),
+        }
+    }
+
+    /// Returns the length of the linked list.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use orx_linked_list::prelude::*;
+    ///
+    /// let mut list = LinkedList::new();
+    /// assert_eq!(0, list.len());
+    ///
+    /// list.push_back('a');
+    /// list.push_front('b');
+    /// assert_eq!(2, list.len());
+    ///
+    /// _ = list.pop_back();
+    /// assert_eq!(1, list.len());
+    ///
+    /// let list = list.built();
+    /// assert_eq!(1, list.len());
+    /// ```
+    pub fn len(&self) -> usize {
+        self.len
+    }
+    /// Returns true if the LinkedList is empty.
+    ///
+    /// This operation should compute in O(1) time.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use orx_linked_list::prelude::*;
+    ///
+    /// let mut list = LinkedList::new();
+    /// assert!(list.is_empty());
+    ///
+    /// list.push_front('a');
+    /// list.push_front('b');
+    /// assert!(!list.is_empty());
+    ///
+    /// let list = list.built();
+    /// assert!(!list.is_empty());
+    /// ```
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Provides a reference to the back element, or None if the list is empty.
+    ///
+    /// This operation should compute in O(1) time.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use orx_linked_list::prelude::*;
+    ///
+    /// let mut list = LinkedList::with_doubling_growth(4);
+    /// assert_eq!(list.back(), None);
+    ///
+    /// list.push_back(42);
+    /// assert_eq!(list.back(), Some(&42));
+    ///
+    /// list.push_front(1);
+    /// assert_eq!(list.back(), Some(&42));
+    ///
+    /// list.push_back(7);
+    /// assert_eq!(list.back(), Some(&7));
+    ///
+    /// let list = list.built();
+    /// assert_eq!(list.back(), Some(&7));
+    /// ```
+    pub fn back(&self) -> Option<&T> {
+        self.back_node().and_then(|node| node.data.as_ref())
+    }
+    /// Provides a mutable reference to the back element, or None if the list is empty.
+    ///
+    /// This operation should compute in O(1) time.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use orx_linked_list::prelude::*;
+    ///
+    /// let mut list = LinkedList::with_linear_growth(16);
+    /// assert_eq!(list.back(), None);
+    ///
+    /// list.push_back(42);
+    /// assert_eq!(list.back(), Some(&42));
+    ///
+    /// let mut list = list.built();
+    /// assert_eq!(list.back(), Some(&42));
+    ///
+    /// match list.back_mut() {
+    ///     None => {},
+    ///     Some(x) => *x = 7,
+    /// }
+    /// assert_eq!(list.back(), Some(&7));
+    /// ```
+    pub fn back_mut(&mut self) -> Option<&mut T> {
+        self.node_ind(self.back_node())
+            .and_then(|ind| self.vec.get_mut(ind).expect(IS_SOME).data.as_mut())
+    }
+    /// Provides a reference to the front element, or None if the list is empty.
+    ///
+    /// This operation should compute in O(1) time.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use orx_linked_list::prelude::*;
+    ///
+    /// let mut list = LinkedList::with_doubling_growth(4);
+    /// assert_eq!(list.front(), None);
+    ///
+    /// list.push_front(42);
+    /// assert_eq!(list.front(), Some(&42));
+    ///
+    /// list.push_back(1);
+    /// assert_eq!(list.front(), Some(&42));
+    ///
+    /// list.push_front(7);
+    /// assert_eq!(list.front(), Some(&7));
+    ///
+    /// let list = list.built();
+    /// assert_eq!(list.front(), Some(&7));
+    /// ```
+    pub fn front(&self) -> Option<&T> {
+        self.front_node().and_then(|node| node.data.as_ref())
+    }
+    /// Provides a mutable reference to the front element, or None if the list is empty.
+    ///
+    /// This operation should compute in O(1) time.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use orx_linked_list::prelude::*;
+    ///
+    /// let mut list = LinkedList::with_linear_growth(16);
+    /// assert_eq!(list.front(), None);
+    ///
+    /// list.push_front(42);
+    /// assert_eq!(list.front(), Some(&42));
+    ///
+    /// let mut list = list.built();
+    /// assert_eq!(list.front(), Some(&42));
+    ///
+    /// match list.front_mut() {
+    ///     None => {},
+    ///     Some(x) => *x = 7,
+    /// }
+    /// assert_eq!(list.front(), Some(&7));
+    /// ```
+    pub fn front_mut(&mut self) -> Option<&mut T> {
+        self.node_ind(self.front_node())
+            .and_then(|ind| self.vec.get_mut(ind).expect(IS_SOME).data.as_mut())
+    }
+
+    /// Returns a reference to element at the `at` position starting from the `front`;
+    /// None when `at` is out of bounds.
+    ///
+    /// This operation requires *O*(*n*) time.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use orx_linked_list::prelude::*;
+    ///
+    /// let mut list = LinkedList::with_linear_growth(8);
+    ///
+    /// // build linked list: a <-> b <-> c
+    /// list.push_back('b');
+    /// list.push_front('a');
+    /// list.push_back('c');
+    ///
+    /// let list = list.built();
+    ///
+    /// assert_eq!(Some(&'a'), list.get_at(0));
+    /// assert_eq!(Some(&'b'), list.get_at(1));
+    /// assert_eq!(Some(&'c'), list.get_at(2));
+    /// assert_eq!(None, list.get_at(3));
+    /// ```
+    pub fn get_at(&self, at: usize) -> Option<&T> {
+        if at < self.len {
+            self.node_at(at).data.as_ref()
+        } else {
+            None
+        }
+    }
+    /// Returns a mutable reference to element at the `at` position starting from the `front`;
+    /// None when `at` is out of bounds.
+    ///
+    /// This operation requires *O*(*n*) time.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use orx_linked_list::prelude::*;
+    ///
+    /// let mut list = LinkedList::with_linear_growth(8);
+    ///
+    /// // build linked list: a <-> b <-> c
+    /// list.push_back('b');
+    /// list.push_front('a');
+    /// list.push_back('c');
+    ///
+    /// let mut list = list.built();
+    ///
+    /// *list.get_mut_at(0).unwrap() = 'x';
+    /// *list.get_mut_at(1).unwrap() = 'y';
+    /// *list.get_mut_at(2).unwrap() = 'z';
+    /// assert_eq!(None, list.get_mut_at(3));
+    ///
+    /// assert_eq!(Some(&'x'), list.get_at(0));
+    /// assert_eq!(Some(&'y'), list.get_at(1));
+    /// assert_eq!(Some(&'z'), list.get_at(2));
+    /// ```
+    #[allow(clippy::unwrap_in_result)]
+    pub fn get_mut_at(&mut self, at: usize) -> Option<&mut T> {
+        if at < self.len {
+            let node = self.node_at(at);
+            let ind = self.node_ind(Some(node))?;
+            self.vec.get_mut(ind).expect(IS_SOME).data.as_mut()
+        } else {
+            None
+        }
+    }
+
+    // helpers
+    /// Returns index of the referenced node:
+    ///
+    /// * might return None only if `node.is_none()`;
+    /// * when `node.is_some()` it is expected to be a valid reference;
+    /// hence, the method panics if not.
+    ///
+    /// # Safety
+    ///
+    /// Since this method, as well as the `LinkedListNode` struct are internal
+    /// to this crate; it is never expected to receive an argument where the
+    /// Some variant of the reference does not belong to the underlying imp
+    /// vector.
+    /// Therefore, `expect` call in the method body will never panic.
+    pub(crate) fn node_ind(&self, node: Option<&'a LinkedListNode<'a, T>>) -> Option<usize> {
+        node.map(|node_ref| self.vec.index_of(node_ref).expect(IS_SOME))
+    }
+    #[inline(always)]
+    #[allow(clippy::unwrap_in_result)]
+    pub(crate) fn back_node(&self) -> Option<&'a LinkedListNode<'a, T>> {
+        self.vec.get(0).expect(IS_SOME).next
+    }
+    #[inline(always)]
+    #[allow(clippy::unwrap_in_result)]
+    pub(crate) fn front_node(&self) -> Option<&'a LinkedListNode<'a, T>> {
+        self.vec.get(0).expect(IS_SOME).prev
+    }
+    fn node_at(&self, at: usize) -> &'a LinkedListNode<'a, T> {
+        self.panic_if_out_of_bounds(at);
+        let mut curr = self.vec.get(0).expect(IS_SOME).prev.expect(IS_SOME);
+        for _ in 0..at {
+            curr = curr.next.expect(IS_SOME);
+        }
+        curr
+    }
+    fn panic_if_out_of_bounds(&self, idx: usize) {
+        assert!(
+            idx < self.len,
+            "Cannot remove at an index outside of the list bounds"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{LinkedList, MemoryUtilization};
+
+    #[test]
+    fn len_is_empty() {
+        let new = || LinkedList::with_doubling_growth(4);
+
+        let list = new().built();
+        assert!(list.is_empty());
+        assert_eq!(list.len(), 0);
+
+        let mut list = new();
+        list.push_back(1);
+        let list = list.built();
+        assert!(!list.is_empty());
+        assert_eq!(list.len(), 1);
+
+        let mut list = new();
+        list.push_back(1);
+        list.push_front(2);
+        let list = list.built();
+        assert!(!list.is_empty());
+        assert_eq!(list.len(), 2);
+
+        let mut list = new();
+        list.push_back(1);
+        list.push_front(2);
+        list.pop_back();
+        let list = list.built();
+        assert!(!list.is_empty());
+        assert_eq!(list.len(), 1);
+
+        let mut list = new();
+        list.push_back(1);
+        list.push_front(2);
+        list.pop_back();
+        list.pop_front();
+        let list = list.built();
+        assert!(list.is_empty());
+        assert_eq!(list.len(), 0);
+
+        let mut list = new();
+        list.push_back(1);
+        list.push_front(2);
+        list.pop_back();
+        list.pop_front();
+        list.push_back(1);
+        list.clear();
+        let list = list.built();
+        assert!(list.is_empty());
+        assert_eq!(list.len(), 0);
+    }
+
+    #[test]
+    fn back_front() {
+        let new = || LinkedList::with_linear_growth(16);
+
+        let list = new().built();
+        assert_eq!(None, list.back());
+        assert_eq!(None, list.front());
+
+        let mut list = new();
+        list.push_back("hello");
+        let list = list.built();
+        assert_eq!(Some(&"hello"), list.back());
+        assert_eq!(Some(&"hello"), list.front());
+
+        let mut list = new();
+        list.push_back("hello");
+        list.push_front("world");
+        let list = list.built();
+        assert_eq!(Some(&"hello"), list.back());
+        assert_eq!(Some(&"world"), list.front());
+
+        let mut list = new();
+        list.push_back("hello");
+        list.push_front("world");
+        list.push_back("hello");
+        list.push_back("World");
+        let list = list.built();
+        assert_eq!(Some(&"World"), list.back());
+        assert_eq!(Some(&"world"), list.front());
+
+        let mut list = new();
+        list.push_back("hello");
+        list.push_front("world");
+        list.push_back("hello");
+        list.push_back("world");
+        list.push_back("!");
+        let list = list.built();
+        assert_eq!(Some(&"!"), list.back());
+    }
+
+    #[test]
+    fn back_front_mut() {
+        let new = || LinkedList::<usize, _>::with_exponential_growth(8, 1.25);
+
+        let mut list = new().built();
+        assert_eq!(None, list.back_mut());
+        assert_eq!(None, list.front_mut());
+
+        // 10 - 20 - 30 - 40
+        let mut list = new();
+        list.push_back(20);
+        list.push_back(30);
+        list.push_front(10);
+        list.push_back(40);
+        let mut list = list.built();
+
+        let back = list.back_mut();
+        assert_eq!(Some(&mut 40), back);
+        *back.expect("is-some") *= 10;
+        assert_eq!(Some(&400), list.back());
+
+        let front = list.front_mut();
+        assert_eq!(Some(&mut 10), front);
+        *front.expect("is-some") *= 10;
+        assert_eq!(Some(&100), list.front());
+    }
+
+    #[test]
+    fn get_at() {
+        let new = || LinkedList::<usize, _>::with_doubling_growth(4);
+
+        let mut list = new();
+        for i in 0..1000 {
+            list.push_back(i);
+        }
+        let mut list = list.built();
+
+        for i in 0..list.len() {
+            assert_eq!(Some(&i), list.get_at(i));
+        }
+        assert_eq!(None, list.get_at(1000));
+
+        for i in 0..list.len() {
+            *list.get_mut_at(i).expect(IS_SOME) *= 10;
+        }
+        assert_eq!(None, list.get_mut_at(1000));
+
+        for i in 0..list.len() {
+            assert_eq!(Some(&(i * 10)), list.get_at(i));
+        }
+        assert_eq!(None, list.get_at(1000));
+    }
+
+    #[test]
+    fn built_and_continue_building() {
+        let mut list = LinkedList::new().with_memory_utilization(MemoryUtilization::Lazy);
+        list.push_back('c');
+        list.push_front('b');
+        list.push_back('d');
+        list.push_back('e');
+        list.push_front('a');
+        list.pop_back();
+        assert_eq!(vec!['a', 'b', 'c', 'd'], list.collect_vec());
+
+        let list = list.built();
+        assert_eq!(vec!['a', 'b', 'c', 'd'], list.collect_vec());
+
+        let list = list.continue_building();
+        assert_eq!(vec!['a', 'b', 'c', 'd'], list.collect_vec());
+        assert_eq!(MemoryUtilization::default(), list.memory_utilization);
+    }
+}

--- a/src/new.rs
+++ b/src/new.rs
@@ -20,7 +20,7 @@ impl<'a, T> LinkedList<'a, T> {
         let imp: ImpVec<_> = SplitVec::new().into();
         imp.push(LinkedListNode::back_front_node());
         Self {
-            imp,
+            vec: imp,
             len: 0,
             memory_utilization: Default::default(),
         }
@@ -44,7 +44,7 @@ impl<'a, T> LinkedList<'a, T> {
         let imp: ImpVec<_> = SplitVec::with_initial_capacity(initial_capacity).into();
         imp.push(LinkedListNode::back_front_node());
         Self {
-            imp,
+            vec: imp,
             len: 0,
             memory_utilization: Default::default(),
         }
@@ -81,7 +81,7 @@ impl<'a, T> LinkedList<'a, T, FixedVec<LinkedListNode<'a, T>>> {
         let imp: ImpVec<_, _> = FixedVec::new(fixed_capacity).into();
         imp.push(LinkedListNode::back_front_node());
         Self {
-            imp,
+            vec: imp,
             len: 0,
             memory_utilization: Default::default(),
         }
@@ -114,7 +114,7 @@ impl<'a, T> LinkedList<'a, T, SplitVec<LinkedListNode<'a, T>, Doubling>> {
         let imp: ImpVec<_, _> = SplitVec::with_doubling_growth(first_fragment_capacity).into();
         imp.push(LinkedListNode::back_front_node());
         Self {
-            imp,
+            vec: imp,
             memory_utilization: Default::default(),
             len: 0,
         }
@@ -147,7 +147,7 @@ impl<'a, T> LinkedList<'a, T, SplitVec<LinkedListNode<'a, T>, Linear>> {
         let imp: ImpVec<_, _> = SplitVec::with_linear_growth(constant_fragment_capacity).into();
         imp.push(LinkedListNode::back_front_node());
         Self {
-            imp,
+            vec: imp,
             memory_utilization: Default::default(),
             len: 0,
         }
@@ -186,7 +186,7 @@ impl<'a, T> LinkedList<'a, T, SplitVec<LinkedListNode<'a, T>, Exponential>> {
             SplitVec::with_exponential_growth(first_fragment_capacity, growth_coefficient).into();
         imp.push(LinkedListNode::back_front_node());
         Self {
-            imp,
+            vec: imp,
             memory_utilization: Default::default(),
             len: 0,
         }
@@ -205,8 +205,8 @@ mod tests {
         let list: LinkedList<char> = list;
         let list: LinkedList<char, SplitVec<LinkedListNode<char>>> = list;
         let list: LinkedList<char, SplitVec<LinkedListNode<char>, Doubling>> = list;
-        assert_eq!(1, list.imp.fragments().len());
-        assert_eq!(4, list.imp.fragments()[0].capacity());
+        assert_eq!(1, list.vec.fragments().len());
+        assert_eq!(4, list.vec.fragments()[0].capacity());
     }
 
     #[test]
@@ -217,7 +217,7 @@ mod tests {
         let list: LinkedList<char> = list;
         let list: LinkedList<char, SplitVec<LinkedListNode<char>>> = list;
         let list: LinkedList<char, SplitVec<LinkedListNode<char>, Doubling>> = list;
-        assert_eq!(1, list.imp.fragments().len());
-        assert_eq!(10, list.imp.fragments()[0].capacity());
+        assert_eq!(1, list.vec.fragments().len());
+        assert_eq!(10, list.vec.fragments()[0].capacity());
     }
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,4 +1,5 @@
 pub use crate::linked_list::LinkedList;
+pub use crate::linked_list_x::LinkedListX;
 pub use crate::mem::{MemoryStatus, MemoryUtilization};
 pub use crate::node::LinkedListNode;
 pub use crate::variants::{


### PR DESCRIPTION
* `LinkedListX` is defined as the structurally immutable version of `LinkedList`. Instead of an `ImpVec`, it holds barely the `PinnedVec` and hence removes one level of indirection.
* `iter` and `collect_vec` methods are implemented for `LinkedListX`.