### PR TITLE
error in derived Default implementation is fixed

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "rust-analyzer.showUnlinkedFileNotification": false
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-linked-list"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "An efficient doubly linked list using thin references with a focus on better cache locality avoiding heap allocations by smart pointers."

--- a/src/common_traits/default.rs
+++ b/src/common_traits/default.rs
@@ -1,0 +1,7 @@
+use crate::LinkedList;
+
+impl<'a, T> Default for LinkedList<'a, T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/common_traits/mod.rs
+++ b/src/common_traits/mod.rs
@@ -1,4 +1,5 @@
 mod clone;
 mod debug;
+mod default;
 mod partial_eq;
 mod partial_eq_x;

--- a/src/linked_list.rs
+++ b/src/linked_list.rs
@@ -4,7 +4,6 @@ use orx_imp_vec::prelude::*;
 /// The LinkedList allows pushing and popping elements at either end in constant time.
 ///
 /// Also see [`LinkedListX`] for the **structurally immutable** version of the linked list.
-#[derive(Default)]
 pub struct LinkedList<'a, T, P = SplitVec<LinkedListNode<'a, T>>>
 where
     T: 'a,

--- a/src/new.rs
+++ b/src/new.rs
@@ -199,14 +199,21 @@ mod tests {
 
     #[test]
     fn new() {
+        fn test_default_list(list: LinkedList<char>) {
+            let list: LinkedList<char> = list;
+            let list: LinkedList<char, SplitVec<LinkedListNode<char>>> = list;
+            let list: LinkedList<char, SplitVec<LinkedListNode<char>, Doubling>> = list;
+            assert_eq!(1, list.vec.fragments().len());
+            assert_eq!(4, list.vec.fragments()[0].capacity());
+        }
+
         let mut list = LinkedList::new();
         list.push_back('a');
+        test_default_list(list);
 
-        let list: LinkedList<char> = list;
-        let list: LinkedList<char, SplitVec<LinkedListNode<char>>> = list;
-        let list: LinkedList<char, SplitVec<LinkedListNode<char>, Doubling>> = list;
-        assert_eq!(1, list.vec.fragments().len());
-        assert_eq!(4, list.vec.fragments()[0].capacity());
+        let mut list = LinkedList::default();
+        list.push_back('a');
+        test_default_list(list);
     }
 
     #[test]


### PR DESCRIPTION
`PinnedVec` or `ImpVec` of every `LinkedList` or `LinkedListX` must contain the sentinel node at position zero holding optional references to the back and front of the linked list. Therefore `#[derive(Default)]` does not work. `Default` is implemented explicitly.