### PR TITLE
Keeping `NodeIndex`es valid

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-linked-list"
-version = "2.1.0"
+version = "2.2.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "An efficient and recursive singly and doubly linked list implementation."
@@ -10,8 +10,8 @@ keywords = ["linked", "list", "vec", "array", "pinned"]
 categories = ["data-structures", "rust-patterns"]
 
 [dependencies]
-orx-selfref-col = "1.2"
-orx-split-vec = "2.1"
+orx-selfref-col = "1.3"
+orx-split-vec = "2.3"
 
 [dev-dependencies]
 rand = "0.8"

--- a/README.md
+++ b/README.md
@@ -5,10 +5,22 @@
 
 An efficient and recursive singly and doubly linked list implementation.
 
+* *efficient*: Please see <a href="#section-benchmarks">benchmarks</a> section for performance reports of common linked list operations. Furthermore, `List` implementation emphasizes safe constant time access and mutations through usage of `NodeIndex`.
+* *singly or doubly*: This is a generic parameter of the `List`. As expected, `Doubly` allows for more operations than `Singly`; however, it keeps two references per node rather than one.
+* *recursive*: `List` allows creating a list by combining two lists in constant time.
+
+
 ## Variants
 
-* `type SinglyLinkedList<'a, T> = List<'a, Singly, T>;`
-* `type DoublyLinkedList<'a, T> = List<'a, Doubly, T>;`
+* **`List<Variant, T>`** where `T` is the type of elements:
+  * **`List<Singly, T>`**: is the singly linked list, where each node holds a reference to the next node.
+    * This is equivalent to `List<Singly<MemoryReclaimOnThreshold<2>>, T>`.
+    * The alternative memory policy is `List<Singly<MemoryReclaimNever>, T>`.
+  * **`List<Doubly, T>`**: is the doubly linked list, where each node holds references to the previous and next nodes.
+    * This is equivalent to `List<Doubly<MemoryReclaimOnThreshold<2>>, T>`.
+    * The alternative memory policy is `List<Doubly<MemoryReclaimNever>, T>`.
+
+*For possible memory management policies, please see <a href="#section-advanced">advanced usage</a> section.*
 
 ## Time Complexity of Methods
 
@@ -18,24 +30,24 @@ The following is the list of methods with constant time **O(1)** time complexity
 
 | ***O(1)*** Methods |
 | -------- |
-| `front`, `back`: access to front and back of the list  |
-| `get`: access to to any node with a given index |
-| `push_front`, `push_back`: push to front or back (*d*) of the list |
-| `pop_front`, `pop_back`: pop from front and back (*d*) of the list |
-| `insert_prev_to`, `insert_next_to`: insert a value previous or next to an existing node with a given index (*d*) |
-| `append_front`, `append_back`: append another list to front or back of the list |
-| `iter`, `iter_from_back`: create an iterator from the front or back (*d*) of the list; iterating has O(n) time complexity |
-| `iter_forward_from`, `iter_backward_from`: create a forward or backward (*d*) iterator from any intermediate node with a given index; iterating has O(n) time complexity |
+| **`front`, `back`**: access to front and back of the list  |
+| **`get`**: access to to any node with a given index |
+| **`push_front`, `push_back`**: push to front or back (*d*) of the list |
+| **`pop_front`, `pop_back`**: pop from front and back (*d*) of the list |
+| **`insert_prev_to`, `insert_next_to`**: insert a value previous or next to an existing node with a given index (*d*) |
+| **`append_front`, `append_back`**: append another list to front or back of the list |
+| **`iter`, `iter_from_back`**: create an iterator from the front or back (*d*) of the list; iterating has O(n) time complexity |
+| **`iter_forward_from`, `iter_backward_from`**: create a forward or backward (*d*) iterator from any intermediate node with a given index; iterating has O(n) time complexity |
 
 | ***O(n)*** Methods |
 | -------- |
-| `index_of`: get the index of an element, which can later be used for ***O(1)*** methods |
-| `contains`, `position_of`: check the existence or position of a value |
-| `insert_at`: insert an element to an arbitrary position of the list |
-| `remove_at`: remove an element from an arbitrary position of the list |
-| `iter`, `iter_from_back`: iterate from the front or back (*d*) of the list |
-| `iter_forward_from`, `iter_backward_from`: iterate in forward or backward (*d*) direction from any intermediate node with a given index |
-| `retain`, `retain_collect`: retain keeping elements satisfying a predicate and optionally collect removed elements |
+| **`index_of`**: get the index of an element, which can later be used for ***O(1)*** methods |
+| **`contains`, `position_of`**: check the existence or position of a value |
+| **`insert_at`**: insert an element to an arbitrary position of the list |
+| **`remove_at`**: remove an element from an arbitrary position of the list |
+| **`iter`, `iter_from_back`**: iterate from the front or back (*d*) of the list |
+| **`iter_forward_from`, `iter_backward_from`**: iterate in forward or backward (*d*) direction from any intermediate node with a given index |
+| **`retain`, `retain_collect`**: retain keeping elements satisfying a predicate and optionally collect removed elements |
 
 
 ## Examples
@@ -52,11 +64,9 @@ fn eq<'a, I: Iterator<Item = &'a u32> + Clone>(iter: I, slice: &[u32]) -> bool {
 }
 
 let _list: List<Singly, u32> = List::new();
-let _list = SinglyLinkedList::<u32>::new();
 let _list: List<Doubly, u32> = List::new();
-let _list = DoublyLinkedList::<u32>::new();
 
-let mut list = DoublyLinkedList::from_iter([3, 4, 5]);
+let mut list = List::<Doubly, _>::from_iter([3, 4, 5]);
 assert_eq!(list.front(), Some(&3));
 assert_eq!(list.back(), Some(&5));
 assert!(eq(list.iter(), &[3, 4, 5]));
@@ -69,11 +79,11 @@ list.push_back(5);
 list.push_front(3);
 assert!(eq(list.iter(), &[3, 4, 5]));
 
-let other = DoublyLinkedList::from_iter([6, 7, 8, 9]);
+let other = List::<Doubly, _>::from_iter([6, 7, 8, 9]);
 list.append_back(other);
 assert!(eq(list.iter(), &[3, 4, 5, 6, 7, 8, 9]));
 
-let other = DoublyLinkedList::from_iter([0, 1, 2]);
+let other = List::<Doubly, _>::from_iter([0, 1, 2]);
 list.append_front(other);
 assert!(eq(list.iter(), &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]));
 
@@ -90,17 +100,16 @@ assert!(eq(odds.iter(), &[1, 3]));
 
 ### `NodeIndex` Usage
 
-`NodeIndex` allows indexing into the collection in constant time with safety guarantees. The indices returned by growth methods, such as `push_back` or `append_next_to`, can be stored externally or an index for a value can be obtained in linear time with `index_of` method.
+`NodeIndex` allows indexing into the collection in constant time with safety guarantees. The indices returned by growth methods, such as `push_back` or `append_next_to`, can be stored externally. Otherwise, an index for a value can be searched and obtained in linear time with `index_of` method. You may see below that these indices enable constant time access and mutation methods.
 
 ```rust
 use orx_linked_list::*;
-use orx_selfref_col::NodeIndexError;
 
 fn eq<'a, I: Iterator<Item = &'a char> + Clone>(iter: I, slice: &[char]) -> bool {
     iter.clone().count() == slice.len() && iter.zip(slice.iter()).all(|(a, b)| a == b)
 }
 
-let mut list = DoublyLinkedList::from_iter(['a', 'b', 'c', 'd']);
+let mut list = List::<Doubly, _>::from_iter(['a', 'b', 'c', 'd']);
 
 let x = list.index_of(&'x');
 assert!(x.is_none());
@@ -131,6 +140,162 @@ assert_eq!(
     list.get_or_error(b).err(),
     Some(NodeIndexError::RemovedNode)
 );
+
+// indices can also be stored on insertion
+let mut list = List::<Doubly, _>::from_iter(['a', 'b', 'c', 'd']);
+
+let x = list.push_back('x'); // grab index of x in O(1) on insertion
+
+_ = list.push_back('e');
+_ = list.push_back('f');
+assert!(eq(list.iter(), &['a', 'b', 'c', 'd', 'x', 'e', 'f']));
+
+let data_x = list.get(x); // O(1)
+assert_eq!(data_x, Some(&'x'));
+
+list.insert_prev_to(x, 'w').unwrap(); // O(1)
+list.insert_next_to(x, 'y').unwrap(); // O(1)
+assert!(eq(list.iter(), &['a', 'b', 'c', 'd', 'w', 'x', 'y', 'e', 'f']));
+```
+
+<div id="section-advanced"></div>
+
+### Advanced Usage
+
+`NodeIndex` is useful in overcoming the major drawback of linked lists that it requires O(n) time to reach the location to apply the O(1) mutation. With holding the required `NodeIndex`, these mutations can be achieved in O(1). However, in order to use these constant time methods, the node index must be valid.
+
+There are three possible reasons why a node index can be invalid and using it in relevant methods returns `NodeIndexError`:
+- **a.** We are using the `NodeIndex` on a different `List`.
+- **b.** We are using the `NodeIndex` while the corresponding element is removed from the `List`.
+- **c.** `List` executed a memory reclaim under the hood in order to improve memory utilization.
+
+Notice that **a** and **b** are obviously mistakes, and hence, receiving an error is straightforward. Actually, we can see that using a `NodeIndex` on a `List` is much safer than using a `usize` on a `Vec`, as we are not protected against these mistakes in standard vector.
+
+However, **c** is completely related with underlying memory management of the `List`. There are two available policies, which are set as the generic argument of both `Singly` and `Doubly`:
+* `MemoryReclaimOnThreshold<D>`
+* `MemoryReclaimNever`
+
+#### Default Policy: `MemoryReclaimOnThreshold<2>`
+
+Adding elements to the `List` leads the underlying storage to grow, as expected. On the other hand, removing elements from the list leaves holes in the corresponding positions. In other words, the values are taken out but the memory location where the value is taken out is not immediately used for new elements.
+
+The `MemoryReclaimOnThreshold<D>` policy automatically reclaims these holes whenever the utilization falls below a threshold. The threshold is a function of the constant generic parameter `D`. Specifically, memory of closed nodes will be reclaimed whenever the ratio of closed nodes to all nodes exceeds one over `2^D`.
+* when `D = 0`: memory will be reclaimed when utilization is below 0.00% (equivalent to never).
+* when `D = 1`: memory will be reclaimed when utilization is below 50.00%.
+* when `D = 2`: memory will be reclaimed when utilization is below 75.00%.
+* when `D = 3`: memory will be reclaimed when utilization is below 87.50%.
+* ...
+
+Underlying `PinnedVec` does not reallocate on memory reclaim operations. Instead, it efficiently moves around the elements within already claimed memory to fill the gaps and repairs the links among the nodes. However, since the positions of the elements will be moved, already obtained `NodeIndex`es might potentially be pointing to wrong positions.
+* Fortunately, `NodeIndex` is aware of this operation. Therefore, it is **not** possible to wrongly use the index. If we obtain a node index, then the list reclaims memory, and then we try to use this node index on this list, we receive `NodeIndexError::ReorganizedCollection`.
+* Unfortunately, the `NodeIndex` now is not useful. All we can do is re-obtain the index by a linear search with methods such as `index_of`.
+
+```rust
+use orx_linked_list::*;
+
+fn float_eq(x: f32, y: f32) -> bool {
+    (x - y).abs() < f32::EPSILON
+}
+
+// MemoryReclaimOnThreshold<2> -> memory will be reclaimed when utilization is below 75%
+let mut list = List::<Doubly, _>::new();
+let a = list.push_back('a');
+list.push_back('b');
+list.push_back('c');
+list.push_back('d');
+list.push_back('e');
+
+assert!(float_eq(list.node_utilization(), 1.00)); // utilization = 5/5 = 100%
+
+// no reorganization; 'a' is still valid
+assert_eq!(list.get_or_error(a), Ok(&'a'));
+assert_eq!(list.get(a), Some(&'a'));
+
+_ = list.pop_back(); // leaves a hole
+
+assert!(float_eq(list.node_utilization(), 0.80)); // utilization = 4/5 = 80%
+
+// no reorganization; 'a' is still valid
+assert_eq!(list.get_or_error(a), Ok(&'a'));
+assert_eq!(list.get(a), Some(&'a'));
+
+_ = list.pop_back(); // leaves the second hole; we have utilization = 3/5 = 60%
+                      // this is below the threshold 75%, and triggers reclaim
+                      // we claim the two unused nodes / holes
+
+assert!(float_eq(list.node_utilization(), 1.00)); // utilization = 3/3 = 100%
+
+// nodes reorganized; 'a' is no more valid
+assert_eq!(
+    list.get_or_error(a),
+    Err(NodeIndexError::ReorganizedCollection)
+);
+assert_eq!(list.get(a), None);
+
+// re-obtain the index
+let a = list.index_of(&'a').unwrap();
+assert_eq!(list.get_or_error(a), Ok(&'a'));
+assert_eq!(list.get(a), Some(&'a'));
+```
+
+#### Alternative Policy: `MemoryReclaimNever`
+
+However, it is possible to make sure that the node indices will always be valid, unless we manually invalidate them, by simply eliminating the case **c**. Setting the memory reclaim policy to `MemoryReclaimNever` guarantees that there will be no automatic or implicit memory reorganizations:
+* use `List<Singly<MemoryReclaimNever>, T>` instead of `List<Singly, T>`, or
+* use `List<Doubly<MemoryReclaimNever>, T>` instead of `List<Doubly, T>`.
+
+The drawback of this approach is that memory utilization can be low if there is a large number of pop or remove operations. However, `List` gives caller the control to manage memory by the following two methods:
+* `List::node_utilization(&self) -> f32` method can be used to see the ratio of number of active/utilized nodes to the number of used nodes. The caller can decide when to take action by the following.
+* `List::reclaim_closed_nodes(&mut self)` method can be used to manually run memory reclaim operation which will bring `node_utilization` to 100% while invalidating already created node indices.
+
+```rust
+use orx_linked_list::*;
+
+fn float_eq(x: f32, y: f32) -> bool {
+    (x - y).abs() < f32::EPSILON
+}
+
+// MemoryReclaimNever -> memory will never be reclaimed automatically
+let mut list = List::<Doubly<MemoryReclaimNever>, _>::new();
+let a = list.push_back('a');
+list.push_back('b');
+list.push_back('c');
+list.push_back('d');
+list.push_back('e');
+
+assert!(float_eq(list.node_utilization(), 1.00)); // utilization = 5/5 = 100%
+
+// no reorganization; 'a' is still valid
+assert_eq!(list.get_or_error(a), Ok(&'a'));
+assert_eq!(list.get(a), Some(&'a'));
+
+_ = list.pop_back(); // leaves a hole
+_ = list.pop_back(); // leaves the second hole
+_ = list.pop_back(); // leaves the third hole
+
+assert!(float_eq(list.node_utilization(), 0.40)); // utilization = 2/5 = 40%
+
+// still no reorganization; 'a' is and will always be valid unless we manually reclaim
+assert_eq!(list.get_or_error(a), Ok(&'a'));
+assert_eq!(list.get(a), Some(&'a'));
+
+list.reclaim_closed_nodes();
+
+// we can manually reclaim memory any time we want to maximize utilization
+assert!(float_eq(list.node_utilization(), 1.00)); // utilization = 2/2 = 100%
+
+// we are still protected by list & index validation
+// nodes reorganized; 'a' is no more valid, we cannot wrongly use the index
+assert_eq!(
+    list.get_or_error(a),
+    Err(NodeIndexError::ReorganizedCollection)
+);
+assert_eq!(list.get(a), None);
+
+// re-obtain the index
+let a = list.index_of(&'a').unwrap();
+assert_eq!(list.get_or_error(a), Ok(&'a'));
+assert_eq!(list.get(a), Some(&'a'));
 ```
 
 ## Internal Features
@@ -139,6 +304,8 @@ assert_eq!(
 * `SelfRefCol` constructs its safety guarantees around the fact that all references will be among elements of the same collection. By preventing bringing in external references or leaking out references, it is safe to build the self referential collection with **regular `&` references**.
 * With careful encapsulation, `SelfRefCol` prevents passing in external references to the list and leaking within list node references to outside. Once this is established, it provides methods to easily mutate inter list node references. These features allowed a very convenient implementation of the linked list in this crate with almost no use of the `unsafe` keyword, no read or writes through pointers and no access by indices. Compared to the `std::collections::LinkedList` implementation, it can be observed that `orx_linked_list::List` is a much **higher level implementation**.
 * Furthermore, `orx_linked_list::List` is **significantly faster** than the standard linked list. One of the main reasons for this is the feature of `SelfRefCol` keeping all close to each other rather than at arbitrary locations in memory which leads to a better cache locality.
+
+<div id="section-benchmarks"></div>
 
 ## Benchmarks
 

--- a/src/common_traits/debug.rs
+++ b/src/common_traits/debug.rs
@@ -2,11 +2,13 @@ use crate::{
     list::List,
     variants::{doubly::Doubly, singly::Singly},
 };
+use orx_selfref_col::MemoryReclaimPolicy;
 use std::fmt::Debug;
 
-impl<'a, T> Debug for List<'a, Singly, T>
+impl<'a, T, M> Debug for List<'a, Singly<M>, T>
 where
     T: Debug,
+    M: MemoryReclaimPolicy,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SinglyLinkedList")
@@ -17,9 +19,10 @@ where
     }
 }
 
-impl<'a, T> Debug for List<'a, Doubly, T>
+impl<'a, T, M> Debug for List<'a, Doubly<M>, T>
 where
     T: Debug,
+    M: 'a + MemoryReclaimPolicy,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("DoublyLinkedList")

--- a/src/common_traits/from_iter.rs
+++ b/src/common_traits/from_iter.rs
@@ -1,7 +1,11 @@
 use crate::{Doubly, List, Singly};
+use orx_selfref_col::MemoryReclaimPolicy;
 use orx_selfref_col::SelfRefCol;
 
-impl<'a, T> FromIterator<T> for List<'a, Singly, T> {
+impl<'a, T, M> FromIterator<T> for List<'a, Singly<M>, T>
+where
+    M: MemoryReclaimPolicy,
+{
     fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
         let mut col = SelfRefCol::from_iter(iter);
 
@@ -25,7 +29,10 @@ impl<'a, T> FromIterator<T> for List<'a, Singly, T> {
     }
 }
 
-impl<'a, T> FromIterator<T> for List<'a, Doubly, T> {
+impl<'a, T, M> FromIterator<T> for List<'a, Doubly<M>, T>
+where
+    M: MemoryReclaimPolicy,
+{
     fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
         let mut col = SelfRefCol::from_iter(iter);
 

--- a/src/common_traits/validators.rs
+++ b/src/common_traits/validators.rs
@@ -2,6 +2,7 @@ use crate::{
     list::List,
     variants::{doubly::Doubly, ends::ListEnds, list_variant::ListVariant, singly::Singly},
 };
+use orx_selfref_col::MemoryReclaimPolicy;
 
 impl<'a, V, T> List<'a, V, T>
 where
@@ -23,14 +24,20 @@ where
     }
 }
 
-impl<'a, T> List<'a, Singly, T> {
+impl<'a, T, M> List<'a, Singly<M>, T>
+where
+    M: MemoryReclaimPolicy,
+{
     #[cfg(test)]
     pub(crate) fn validate_list(&self) {
         self.validate_next();
     }
 }
 
-impl<'a, T> List<'a, Doubly, T> {
+impl<'a, T, M> List<'a, Doubly<M>, T>
+where
+    M: MemoryReclaimPolicy,
+{
     #[cfg(test)]
     pub(crate) fn validate_list(&self) {
         self.validate_next();

--- a/src/iterators/forward.rs
+++ b/src/iterators/forward.rs
@@ -1,7 +1,6 @@
-use std::iter::FusedIterator;
-
 use crate::variants::list_variant::ListVariant;
 use orx_selfref_col::{Node, NodeRefSingle, NodeRefs};
+use std::iter::FusedIterator;
 
 pub struct IterForward<'iter, 'a, V, T>
 where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,10 +5,22 @@
 //!
 //! An efficient and recursive singly and doubly linked list implementation.
 //!
+//! * *efficient*: Please see <a href="#section-benchmarks">benchmarks</a> section for performance reports of common linked list operations. Furthermore, `List` implementation emphasizes safe constant time access and mutations through usage of `NodeIndex`.
+//! * *singly or doubly*: This is a generic parameter of the `List`. As expected, `Doubly` allows for more operations than `Singly`; however, it keeps two references per node rather than one.
+//! * *recursive*: `List` allows creating a list by combining two lists in constant time.
+//!
+//!
 //! ## Variants
 //!
-//! * `type SinglyLinkedList<'a, T> = List<'a, Singly, T>;`
-//! * `type DoublyLinkedList<'a, T> = List<'a, Doubly, T>;`
+//! * **`List<Variant, T>`** where `T` is the type of elements:
+//!   * **`List<Singly, T>`**: is the singly linked list, where each node holds a reference to the next node.
+//!     * This is equivalent to `List<Singly<MemoryReclaimOnThreshold<2>>, T>`.
+//!     * The alternative memory policy is `List<Singly<MemoryReclaimNever>, T>`.
+//!   * **`List<Doubly, T>`**: is the doubly linked list, where each node holds references to the previous and next nodes.
+//!     * This is equivalent to `List<Doubly<MemoryReclaimOnThreshold<2>>, T>`.
+//!     * The alternative memory policy is `List<Doubly<MemoryReclaimNever>, T>`.
+//!
+//! *For possible memory management policies, please see <a href="#section-advanced">advanced usage</a> section.*
 //!
 //! ## Time Complexity of Methods
 //!
@@ -18,24 +30,24 @@
 //!
 //! | ***O(1)*** Methods |
 //! | -------- |
-//! | `front`, `back`: access to front and back of the list  |
-//! | `get`: access to to any node with a given index |
-//! | `push_front`, `push_back`: push to front or back (*d*) of the list |
-//! | `pop_front`, `pop_back`: pop from front and back (*d*) of the list |
-//! | `insert_prev_to`, `insert_next_to`: insert a value previous or next to an existing node with a given index (*d*) |
-//! | `append_front`, `append_back`: append another list to front or back of the list |
-//! | `iter`, `iter_from_back`: create an iterator from the front or back (*d*) of the list; iterating has O(n) time complexity |
-//! | `iter_forward_from`, `iter_backward_from`: create a forward or backward (*d*) iterator from any intermediate node with a given index; iterating has O(n) time complexity |
+//! | **`front`, `back`**: access to front and back of the list  |
+//! | **`get`**: access to to any node with a given index |
+//! | **`push_front`, `push_back`**: push to front or back (*d*) of the list |
+//! | **`pop_front`, `pop_back`**: pop from front and back (*d*) of the list |
+//! | **`insert_prev_to`, `insert_next_to`**: insert a value previous or next to an existing node with a given index (*d*) |
+//! | **`append_front`, `append_back`**: append another list to front or back of the list |
+//! | **`iter`, `iter_from_back`**: create an iterator from the front or back (*d*) of the list; iterating has O(n) time complexity |
+//! | **`iter_forward_from`, `iter_backward_from`**: create a forward or backward (*d*) iterator from any intermediate node with a given index; iterating has O(n) time complexity |
 //!
 //! | ***O(n)*** Methods |
 //! | -------- |
-//! | `index_of`: get the index of an element, which can later be used for ***O(1)*** methods |
-//! | `contains`, `position_of`: check the existence or position of a value |
-//! | `insert_at`: insert an element to an arbitrary position of the list |
-//! | `remove_at`: remove an element from an arbitrary position of the list |
-//! | `iter`, `iter_from_back`: iterate from the front or back (*d*) of the list |
-//! | `iter_forward_from`, `iter_backward_from`: iterate in forward or backward (*d*) direction from any intermediate node with a given index |
-//! | `retain`, `retain_collect`: retain keeping elements satisfying a predicate and optionally collect removed elements |
+//! | **`index_of`**: get the index of an element, which can later be used for ***O(1)*** methods |
+//! | **`contains`, `position_of`**: check the existence or position of a value |
+//! | **`insert_at`**: insert an element to an arbitrary position of the list |
+//! | **`remove_at`**: remove an element from an arbitrary position of the list |
+//! | **`iter`, `iter_from_back`**: iterate from the front or back (*d*) of the list |
+//! | **`iter_forward_from`, `iter_backward_from`**: iterate in forward or backward (*d*) direction from any intermediate node with a given index |
+//! | **`retain`, `retain_collect`**: retain keeping elements satisfying a predicate and optionally collect removed elements |
 //!
 //!
 //! ## Examples
@@ -52,11 +64,9 @@
 //! }
 //!
 //! let _list: List<Singly, u32> = List::new();
-//! let _list = SinglyLinkedList::<u32>::new();
 //! let _list: List<Doubly, u32> = List::new();
-//! let _list = DoublyLinkedList::<u32>::new();
 //!
-//! let mut list = DoublyLinkedList::from_iter([3, 4, 5]);
+//! let mut list = List::<Doubly, _>::from_iter([3, 4, 5]);
 //! assert_eq!(list.front(), Some(&3));
 //! assert_eq!(list.back(), Some(&5));
 //! assert!(eq(list.iter(), &[3, 4, 5]));
@@ -69,11 +79,11 @@
 //! list.push_front(3);
 //! assert!(eq(list.iter(), &[3, 4, 5]));
 //!
-//! let other = DoublyLinkedList::from_iter([6, 7, 8, 9]);
+//! let other = List::<Doubly, _>::from_iter([6, 7, 8, 9]);
 //! list.append_back(other);
 //! assert!(eq(list.iter(), &[3, 4, 5, 6, 7, 8, 9]));
 //!
-//! let other = DoublyLinkedList::from_iter([0, 1, 2]);
+//! let other = List::<Doubly, _>::from_iter([0, 1, 2]);
 //! list.append_front(other);
 //! assert!(eq(list.iter(), &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]));
 //!
@@ -90,17 +100,16 @@
 //!
 //! ### `NodeIndex` Usage
 //!
-//! `NodeIndex` allows indexing into the collection in constant time with safety guarantees. The indices returned by growth methods, such as `push_back` or `append_next_to`, can be stored externally or an index for a value can be obtained in linear time with `index_of` method.
+//! `NodeIndex` allows indexing into the collection in constant time with safety guarantees. The indices returned by growth methods, such as `push_back` or `append_next_to`, can be stored externally. Otherwise, an index for a value can be searched and obtained in linear time with `index_of` method. You may see below that these indices enable constant time access and mutation methods.
 //!
 //! ```rust
 //! use orx_linked_list::*;
-//! use orx_selfref_col::NodeIndexError;
 //!
 //! fn eq<'a, I: Iterator<Item = &'a char> + Clone>(iter: I, slice: &[char]) -> bool {
 //!     iter.clone().count() == slice.len() && iter.zip(slice.iter()).all(|(a, b)| a == b)
 //! }
 //!
-//! let mut list = DoublyLinkedList::from_iter(['a', 'b', 'c', 'd']);
+//! let mut list = List::<Doubly, _>::from_iter(['a', 'b', 'c', 'd']);
 //!
 //! let x = list.index_of(&'x');
 //! assert!(x.is_none());
@@ -131,6 +140,162 @@
 //!     list.get_or_error(b).err(),
 //!     Some(NodeIndexError::RemovedNode)
 //! );
+//!
+//! // indices can also be stored on insertion
+//! let mut list = List::<Doubly, _>::from_iter(['a', 'b', 'c', 'd']);
+//!
+//! let x = list.push_back('x'); // grab index of x in O(1) on insertion
+//!
+//! _ = list.push_back('e');
+//! _ = list.push_back('f');
+//! assert!(eq(list.iter(), &['a', 'b', 'c', 'd', 'x', 'e', 'f']));
+//!
+//! let data_x = list.get(x); // O(1)
+//! assert_eq!(data_x, Some(&'x'));
+//!
+//! list.insert_prev_to(x, 'w').unwrap(); // O(1)
+//! list.insert_next_to(x, 'y').unwrap(); // O(1)
+//! assert!(eq(list.iter(), &['a', 'b', 'c', 'd', 'w', 'x', 'y', 'e', 'f']));
+//! ```
+//!
+//! <div id="section-advanced"></div>
+//!
+//! ### Advanced Usage
+//!
+//! `NodeIndex` is useful in overcoming the major drawback of linked lists that it requires O(n) time to reach the location to apply the O(1) mutation. With holding the required `NodeIndex`, these mutations can be achieved in O(1). However, in order to use these constant time methods, the node index must be valid.
+//!
+//! There are three possible reasons why a node index can be invalid and using it in relevant methods returns `NodeIndexError`:
+//! - **a.** We are using the `NodeIndex` on a different `List`.
+//! - **b.** We are using the `NodeIndex` while the corresponding element is removed from the `List`.
+//! - **c.** `List` executed a memory reclaim under the hood in order to improve memory utilization.
+//!
+//! Notice that **a** and **b** are obviously mistakes, and hence, receiving an error is straightforward. Actually, we can see that using a `NodeIndex` on a `List` is much safer than using a `usize` on a `Vec`, as we are not protected against these mistakes in standard vector.
+//!
+//! However, **c** is completely related with underlying memory management of the `List`. There are two available policies, which are set as the generic argument of both `Singly` and `Doubly`:
+//! * `MemoryReclaimOnThreshold<D>`
+//! * `MemoryReclaimNever`
+//!
+//! #### Default Policy: `MemoryReclaimOnThreshold<2>`
+//!
+//! Adding elements to the `List` leads the underlying storage to grow, as expected. On the other hand, removing elements from the list leaves holes in the corresponding positions. In other words, the values are taken out but the memory location where the value is taken out is not immediately used for new elements.
+//!
+//! The `MemoryReclaimOnThreshold<D>` policy automatically reclaims these holes whenever the utilization falls below a threshold. The threshold is a function of the constant generic parameter `D`. Specifically, memory of closed nodes will be reclaimed whenever the ratio of closed nodes to all nodes exceeds one over `2^D`.
+//! * when `D = 0`: memory will be reclaimed when utilization is below 0.00% (equivalent to never).
+//! * when `D = 1`: memory will be reclaimed when utilization is below 50.00%.
+//! * when `D = 2`: memory will be reclaimed when utilization is below 75.00%.
+//! * when `D = 3`: memory will be reclaimed when utilization is below 87.50%.
+//! * ...
+//!
+//! Underlying `PinnedVec` does not reallocate on memory reclaim operations. Instead, it efficiently moves around the elements within already claimed memory to fill the gaps and repairs the links among the nodes. However, since the positions of the elements will be moved, already obtained `NodeIndex`es might potentially be pointing to wrong positions.
+//! * Fortunately, `NodeIndex` is aware of this operation. Therefore, it is **not** possible to wrongly use the index. If we obtain a node index, then the list reclaims memory, and then we try to use this node index on this list, we receive `NodeIndexError::ReorganizedCollection`.
+//! * Unfortunately, the `NodeIndex` now is not useful. All we can do is re-obtain the index by a linear search with methods such as `index_of`.
+//!
+//! ```rust
+//! use orx_linked_list::*;
+//!
+//! fn float_eq(x: f32, y: f32) -> bool {
+//!     (x - y).abs() < f32::EPSILON
+//! }
+//!
+//! // MemoryReclaimOnThreshold<2> -> memory will be reclaimed when utilization is below 75%
+//! let mut list = List::<Doubly, _>::new();
+//! let a = list.push_back('a');
+//! list.push_back('b');
+//! list.push_back('c');
+//! list.push_back('d');
+//! list.push_back('e');
+//!
+//! assert!(float_eq(list.node_utilization(), 1.00)); // utilization = 5/5 = 100%
+//!
+//! // no reorganization; 'a' is still valid
+//! assert_eq!(list.get_or_error(a), Ok(&'a'));
+//! assert_eq!(list.get(a), Some(&'a'));
+//!
+//! _ = list.pop_back(); // leaves a hole
+//!
+//! assert!(float_eq(list.node_utilization(), 0.80)); // utilization = 4/5 = 80%
+//!
+//! // no reorganization; 'a' is still valid
+//! assert_eq!(list.get_or_error(a), Ok(&'a'));
+//! assert_eq!(list.get(a), Some(&'a'));
+//!
+//! _ = list.pop_back(); // leaves the second hole; we have utilization = 3/5 = 60%
+//!                       // this is below the threshold 75%, and triggers reclaim
+//!                       // we claim the two unused nodes / holes
+//!
+//! assert!(float_eq(list.node_utilization(), 1.00)); // utilization = 3/3 = 100%
+//!
+//! // nodes reorganized; 'a' is no more valid
+//! assert_eq!(
+//!     list.get_or_error(a),
+//!     Err(NodeIndexError::ReorganizedCollection)
+//! );
+//! assert_eq!(list.get(a), None);
+//!
+//! // re-obtain the index
+//! let a = list.index_of(&'a').unwrap();
+//! assert_eq!(list.get_or_error(a), Ok(&'a'));
+//! assert_eq!(list.get(a), Some(&'a'));
+//! ```
+//!
+//! #### Alternative Policy: `MemoryReclaimNever`
+//!
+//! However, it is possible to make sure that the node indices will always be valid, unless we manually invalidate them, by simply eliminating the case **c**. Setting the memory reclaim policy to `MemoryReclaimNever` guarantees that there will be no automatic or implicit memory reorganizations:
+//! * use `List<Singly<MemoryReclaimNever>, T>` instead of `List<Singly, T>`, or
+//! * use `List<Doubly<MemoryReclaimNever>, T>` instead of `List<Doubly, T>`.
+//!
+//! The drawback of this approach is that memory utilization can be low if there is a large number of pop or remove operations. However, `List` gives caller the control to manage memory by the following two methods:
+//! * `List::node_utilization(&self) -> f32` method can be used to see the ratio of number of active/utilized nodes to the number of used nodes. The caller can decide when to take action by the following.
+//! * `List::reclaim_closed_nodes(&mut self)` method can be used to manually run memory reclaim operation which will bring `node_utilization` to 100% while invalidating already created node indices.
+//!
+//! ```rust
+//! use orx_linked_list::*;
+//!
+//! fn float_eq(x: f32, y: f32) -> bool {
+//!     (x - y).abs() < f32::EPSILON
+//! }
+//!
+//! // MemoryReclaimNever -> memory will never be reclaimed automatically
+//! let mut list = List::<Doubly<MemoryReclaimNever>, _>::new();
+//! let a = list.push_back('a');
+//! list.push_back('b');
+//! list.push_back('c');
+//! list.push_back('d');
+//! list.push_back('e');
+//!
+//! assert!(float_eq(list.node_utilization(), 1.00)); // utilization = 5/5 = 100%
+//!
+//! // no reorganization; 'a' is still valid
+//! assert_eq!(list.get_or_error(a), Ok(&'a'));
+//! assert_eq!(list.get(a), Some(&'a'));
+//!
+//! _ = list.pop_back(); // leaves a hole
+//! _ = list.pop_back(); // leaves the second hole
+//! _ = list.pop_back(); // leaves the third hole
+//!
+//! assert!(float_eq(list.node_utilization(), 0.40)); // utilization = 2/5 = 40%
+//!
+//! // still no reorganization; 'a' is and will always be valid unless we manually reclaim
+//! assert_eq!(list.get_or_error(a), Ok(&'a'));
+//! assert_eq!(list.get(a), Some(&'a'));
+//!
+//! list.reclaim_closed_nodes();
+//!
+//! // we can manually reclaim memory any time we want to maximize utilization
+//! assert!(float_eq(list.node_utilization(), 1.00)); // utilization = 2/2 = 100%
+//!
+//! // we are still protected by list & index validation
+//! // nodes reorganized; 'a' is no more valid, we cannot wrongly use the index
+//! assert_eq!(
+//!     list.get_or_error(a),
+//!     Err(NodeIndexError::ReorganizedCollection)
+//! );
+//! assert_eq!(list.get(a), None);
+//!
+//! // re-obtain the index
+//! let a = list.index_of(&'a').unwrap();
+//! assert_eq!(list.get_or_error(a), Ok(&'a'));
+//! assert_eq!(list.get(a), Some(&'a'));
 //! ```
 //!
 //! ## Internal Features
@@ -139,6 +304,8 @@
 //! * `SelfRefCol` constructs its safety guarantees around the fact that all references will be among elements of the same collection. By preventing bringing in external references or leaking out references, it is safe to build the self referential collection with **regular `&` references**.
 //! * With careful encapsulation, `SelfRefCol` prevents passing in external references to the list and leaking within list node references to outside. Once this is established, it provides methods to easily mutate inter list node references. These features allowed a very convenient implementation of the linked list in this crate with almost no use of the `unsafe` keyword, no read or writes through pointers and no access by indices. Compared to the `std::collections::LinkedList` implementation, it can be observed that `orx_linked_list::List` is a much **higher level implementation**.
 //! * Furthermore, `orx_linked_list::List` is **significantly faster** than the standard linked list. One of the main reasons for this is the feature of `SelfRefCol` keeping all close to each other rather than at arbitrary locations in memory which leads to a better cache locality.
+//!
+//! <div id="section-benchmarks"></div>
 //!
 //! ## Benchmarks
 //!
@@ -181,4 +348,7 @@ mod option_utils;
 mod variants;
 
 pub use list::{DoublyLinkedList, List, SinglyLinkedList};
+pub use orx_selfref_col::{
+    MemoryReclaimNever, MemoryReclaimOnThreshold, MemoryReclaimPolicy, NodeIndexError,
+};
 pub use variants::{doubly::Doubly, singly::Singly};

--- a/src/variants/list_variant.rs
+++ b/src/variants/list_variant.rs
@@ -1,4 +1,4 @@
-use orx_selfref_col::{NodeDataLazyClose, NodeRefSingle, NodeRefsArray, Variant};
+use orx_selfref_col::{NodeDataLazyClose, NodeRefSingle, NodeRefs, NodeRefsArray, Variant};
 
 pub trait ListVariant<'a, T>:
     Variant<
@@ -12,6 +12,9 @@ where
     Self: 'a,
     T: 'a,
 {
+    type PrevNode: NodeRefs<'a, Self, T>;
+    type NextNode: NodeRefs<'a, Self, T>;
+
     #[cfg(test)]
     fn validate(list: &crate::list::List<'a, Self, T>)
     where

--- a/src/variants/singly.rs
+++ b/src/variants/singly.rs
@@ -1,17 +1,22 @@
 use super::{ends::ListEnds, list_variant::ListVariant};
+use crate::list::DefaultMemoryPolicy;
 use orx_selfref_col::{
-    MemoryReclaimOnThreshold, Node, NodeDataLazyClose, NodeRefNone, NodeRefSingle, NodeRefs,
+    MemoryReclaimPolicy, Node, NodeDataLazyClose, NodeRefNone, NodeRefSingle, NodeRefs,
     NodeRefsArray, Variant,
 };
+use std::marker::PhantomData;
 
-pub type EndsSingly<'a, T> = NodeRefsArray<'a, 2, Singly, T>;
+pub type EndsSingly<'a, T, M> = NodeRefsArray<'a, 2, Singly<M>, T>;
 
-impl<'a, T> ListEnds<'a, Singly, T> for EndsSingly<'a, T> {
-    fn front(&self) -> Option<&'a Node<'a, Singly, T>> {
+impl<'a, T, M> ListEnds<'a, Singly<M>, T> for EndsSingly<'a, T, M>
+where
+    M: MemoryReclaimPolicy,
+{
+    fn front(&self) -> Option<&'a Node<'a, Singly<M>, T>> {
         self.get()[0]
     }
 
-    fn back(&self) -> Option<&'a Node<'a, Singly, T>> {
+    fn back(&self) -> Option<&'a Node<'a, Singly<M>, T>> {
         self.get()[1]
     }
 }
@@ -21,11 +26,17 @@ impl<'a, T> ListEnds<'a, Singly, T> for EndsSingly<'a, T> {
 /// * The list keeps track of its `front`.
 /// * It is possible to iterate from the `front` to the back of the list.
 #[derive(Clone, Copy, Debug)]
-pub struct Singly;
+pub struct Singly<M = DefaultMemoryPolicy>
+where
+    M: MemoryReclaimPolicy,
+{
+    phantom: PhantomData<M>,
+}
 
-impl<'a, T> Variant<'a, T> for Singly
+impl<'a, T, M> Variant<'a, T> for Singly<M>
 where
     T: 'a,
+    M: 'a + MemoryReclaimPolicy,
 {
     type Storage = NodeDataLazyClose<T>;
 
@@ -33,15 +44,20 @@ where
 
     type Next = NodeRefSingle<'a, Self, T>;
 
-    type Ends = EndsSingly<'a, T>;
+    type Ends = EndsSingly<'a, T, M>;
 
-    type MemoryReclaim = MemoryReclaimOnThreshold<2>;
+    type MemoryReclaim = M;
 }
 
-impl<'a, T> ListVariant<'a, T> for Singly
+impl<'a, T, M> ListVariant<'a, T> for Singly<M>
 where
     T: 'a,
+    M: 'a + MemoryReclaimPolicy,
 {
+    type PrevNode = NodeRefNone;
+
+    type NextNode = NodeRefSingle<'a, Self, T>;
+
     #[cfg(test)]
     fn validate(list: &crate::list::List<'a, Self, T>)
     where


### PR DESCRIPTION
* `MemoryReclaimPolicy` generic argument is added to the list variants `Singly` and `Doubly`. In the prior versions, all lists used `MemoryReclaimOnThredhold` as the memory reclaim policy. This policy is still the default policy. However, the user may prefer to use `MemoryReclaimNever`.
* `MemoryReclaimNever` will make sure that the indices will always be valid.
* `node_utilization` and `reclaim_closed_nodes` methods are exposed. This gives control to the the user to manually manage memory utilization. Note that these methods are crucial when `MemoryReclaimNever` is used.