### PR TITLE
upgrade-pinned-vec-3.21

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-linked-list"
-version = "3.9.1"
+version = "3.10.0"
 edition = "2024"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "A linked list implementation with unique features and an extended list of constant time methods providing high performance traversals and mutations."
@@ -12,12 +12,12 @@ categories = ["data-structures", "rust-patterns", "no-std"]
 [dependencies]
 orx-iterable = { version = "1.3.0", default-features = false }
 orx-pseudo-default = { version = "2.1.0", default-features = false }
-orx-pinned-vec = { version = "3.16.0", default-features = false }
-orx-fixed-vec = { version = "3.17.0", default-features = false }
-orx-split-vec = { version = "3.17.0", default-features = false }
-orx-concurrent-iter = { version = "2.1.0", default-features = false }
-orx-selfref-col = { version = "2.9.0", default-features = false }
-orx-parallel = { version = "2.1.0", default-features = false, optional = true }
+orx-pinned-vec = { version = "3.21.0", default-features = false }
+orx-fixed-vec = { version = "3.22.0", default-features = false }
+orx-split-vec = { version = "3.22.0", default-features = false }
+orx-concurrent-iter = { version = "3.1.0", default-features = false }
+orx-selfref-col = { version = "2.14.0", default-features = false }
+orx-parallel = { version = "3.3.0", default-features = false, optional = true }
 
 [dev-dependencies]
 clap = { version = "4.5.38", features = ["derive"] }

--- a/src/list/ends_traits/doubly_ends_mut.rs
+++ b/src/list/ends_traits/doubly_ends_mut.rs
@@ -550,17 +550,17 @@ where
             }
         }
 
-        if let Some(old_front) = old_front {
-            if old_front == mid {
-                // old back is moved away
-                let old_back = old_back.expect("exists");
-                match old_front == old_back {
-                    false => {
-                        let new_front = old_next.expect("exists");
-                        self.ends_mut().set_some(FRONT_IDX, new_front);
-                    }
-                    true => { /* singleton, no update */ }
+        if let Some(old_front) = old_front
+            && old_front == mid
+        {
+            // old back is moved away
+            let old_back = old_back.expect("exists");
+            match old_front == old_back {
+                false => {
+                    let new_front = old_next.expect("exists");
+                    self.ends_mut().set_some(FRONT_IDX, new_front);
                 }
+                true => { /* singleton, no update */ }
             }
         }
     }
@@ -655,17 +655,17 @@ where
             }
         }
 
-        if let Some(old_back) = old_back {
-            if old_back == mid {
-                // old back is moved away
-                let old_front = old_front.expect("exists");
-                match old_front == old_back {
-                    false => {
-                        let new_back = old_prev.expect("exists");
-                        self.ends_mut().set_some(BACK_IDX, new_back);
-                    }
-                    true => { /* singleton, no update */ }
+        if let Some(old_back) = old_back
+            && old_back == mid
+        {
+            // old back is moved away
+            let old_front = old_front.expect("exists");
+            match old_front == old_back {
+                false => {
+                    let new_back = old_prev.expect("exists");
+                    self.ends_mut().set_some(BACK_IDX, new_back);
                 }
+                true => { /* singleton, no update */ }
             }
         }
     }

--- a/src/list/get_doubly.rs
+++ b/src/list/get_doubly.rs
@@ -77,7 +77,7 @@ where
     /// let slice = list.slice(&idx[4]..&idx[1]);
     /// assert!(slice.eq_to_iter_vals([4, 5, 6, 7, 8, 9]));
     /// ```
-    pub fn slice<'a, R>(&self, range: R) -> ListSlice<Doubly<T>, M>
+    pub fn slice<'a, R>(&self, range: R) -> ListSlice<'_, Doubly<T>, M>
     where
         R: RangeBounds<&'a DoublyIdx<T>>,
         T: 'a,

--- a/src/list/mut_doubly.rs
+++ b/src/list/mut_doubly.rs
@@ -281,7 +281,7 @@ where
     /// let slice = list.slice_mut(&idx[4]..&idx[1]);
     /// assert!(slice.eq_to_iter_vals([4, 5, 6, 7, 8, 9]));
     /// ```
-    pub fn slice_mut<'a, R>(&mut self, range: R) -> ListSliceMut<Doubly<T>, M, P>
+    pub fn slice_mut<'a, R>(&mut self, range: R) -> ListSliceMut<'_, Doubly<T>, M, P>
     where
         R: RangeBounds<&'a DoublyIdx<T>>,
         T: 'a,

--- a/src/list/mut_singly.rs
+++ b/src/list/mut_singly.rs
@@ -118,7 +118,7 @@ where
     ///
     /// assert!(list.eq_to_iter_vals([40, 41, 42]));
     /// ```
-    pub fn iter_mut(&mut self) -> SinglyIterMut<T, P> {
+    pub fn iter_mut(&mut self) -> SinglyIterMut<'_, T, P> {
         SinglyIterMut::new_old(&mut self.0)
     }
 }

--- a/src/tests/doubly.rs
+++ b/src/tests/doubly.rs
@@ -109,14 +109,14 @@ where
         assert!(iter.next().is_none());
     }
 
-    fn next(&self, ptr: &NodePtr<Doubly<T>>) -> Option<PtrAndNode<T>> {
+    fn next(&self, ptr: &NodePtr<Doubly<T>>) -> Option<PtrAndNode<'_, T>> {
         self.0.node(ptr).next().get().map(|p| {
             let next_node = self.0.node(p);
             (p.clone(), next_node)
         })
     }
 
-    fn prev(&self, ptr: &NodePtr<Doubly<T>>) -> Option<PtrAndNode<T>> {
+    fn prev(&self, ptr: &NodePtr<Doubly<T>>) -> Option<PtrAndNode<'_, T>> {
         self.0.node(ptr).prev().get().map(|p| {
             let prev_node = self.0.node(p);
             (p.clone(), prev_node)

--- a/src/tests/singly.rs
+++ b/src/tests/singly.rs
@@ -67,7 +67,7 @@ where
         assert!(iter.next().is_none());
     }
 
-    fn next(&self, ptr: &NodePtr<Singly<T>>) -> Option<PtrAndNode<T>> {
+    fn next(&self, ptr: &NodePtr<Singly<T>>) -> Option<PtrAndNode<'_, T>> {
         self.0.node(ptr).next().get().cloned().map(|p| {
             let next_node = self.0.node(&p);
             (p, next_node)


### PR DESCRIPTION
Upgrades PinnedVec for improved safety guarantees: https://github.com/orxfun/orx-pinned-vec/releases/tag/3.21.0

Also upgrades orx-parallel dependency.
